### PR TITLE
Implement "outdated" support

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2,6 +2,7 @@ use crate::errors::*;
 use postgres::{Client, NoTls};
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
@@ -12,7 +13,34 @@ const CACHE_EXPIRE: Duration = Duration::from_secs(90 * 60);
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CacheEntry {
     pub from: SystemTime,
-    pub found: bool,
+    pub crate_status: CrateStatus,
+}
+
+/// The current status of a crate in Debian.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CrateStatus {
+    Available,
+    AvailableInNew,
+    Outdated,
+    Missing,
+}
+
+impl CrateStatus {
+    pub(crate) fn in_debian(&self) -> bool {
+        *self != CrateStatus::Missing
+    }
+}
+
+impl fmt::Display for CrateStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str = match self {
+            CrateStatus::Available => "in debian",
+            CrateStatus::AvailableInNew => "in debian NEW queue",
+            CrateStatus::Outdated => "outdated",
+            CrateStatus::Missing => "missing",
+        };
+        write!(f, "{}", str)
+    }
 }
 
 // TODO: also use this for outdated check(?)
@@ -64,7 +92,7 @@ impl Connection {
         target: &str,
         package: &str,
         version: &str,
-    ) -> Result<Option<bool>, Error> {
+    ) -> Result<Option<CrateStatus>, Error> {
         let path = self.cache_path(target, package, version);
 
         if !path.exists() {
@@ -72,13 +100,15 @@ impl Connection {
         }
 
         let buf = fs::read(path)?;
-        let cache: CacheEntry = serde_json::from_slice(&buf)?;
-
-        if SystemTime::now().duration_since(cache.from)? > CACHE_EXPIRE {
-            Ok(None)
-        } else {
-            Ok(Some(cache.found))
+        // ignore I/O and deserialization errors when trying to read the cache
+        if let Ok(cache) = serde_json::from_slice::<CacheEntry>(&buf) {
+            if SystemTime::now().duration_since(cache.from)? > CACHE_EXPIRE {
+                return Ok(None);
+            } else {
+                return Ok(Some(cache.crate_status));
+            }
         }
+        Ok(None)
     }
 
     fn write_cache(
@@ -86,49 +116,53 @@ impl Connection {
         target: &str,
         package: &str,
         version: &str,
-        found: bool,
+        crate_status: CrateStatus,
     ) -> Result<(), Error> {
         let cache = CacheEntry {
             from: SystemTime::now(),
-            found,
+            crate_status: crate_status,
         };
         let buf = serde_json::to_vec(&cache)?;
         fs::write(self.cache_path(target, package, version), &buf)?;
         Ok(())
     }
 
-    pub fn search(&mut self, package: &str, version: &str) -> Result<bool, Error> {
-        if let Some(found) = self.check_cache("sid", package, version)? {
-            return Ok(found);
+    pub fn search(&mut self, package: &str, version: &str) -> Result<CrateStatus, Error> {
+        if let Some(crate_status) = self.check_cache("sid", package, version)? {
+            return Ok(crate_status);
         }
 
         // config.shell().status("Querying", format!("sid: {}", package))?;
         info!("Querying -> sid: {}", package);
-        let found = self.search_generic(
+        let crate_status = self.search_generic(
             "SELECT version::text FROM sources WHERE source=$1 AND release='sid';",
             package,
             version,
         )?;
 
-        self.write_cache("sid", package, version, found)?;
-        Ok(found)
+        self.write_cache("sid", package, version, crate_status)?;
+        Ok(crate_status)
     }
 
-    pub fn search_new(&mut self, package: &str, version: &str) -> Result<bool, Error> {
-        if let Some(found) = self.check_cache("new", package, version)? {
-            return Ok(found);
+    pub fn search_new(&mut self, package: &str, version: &str) -> Result<CrateStatus, Error> {
+        if let Some(crate_status) = self.check_cache("new", package, version)? {
+            return Ok(crate_status);
         }
 
         // config.shell().status("Querying", format!("new: {}", package))?;
         info!("Querying -> new: {}", package);
-        let found = self.search_generic(
+        let mut crate_status = self.search_generic(
             "SELECT version::text FROM new_sources WHERE source=$1;",
             package,
             version,
         )?;
 
-        self.write_cache("new", package, version, found)?;
-        Ok(found)
+        if crate_status == CrateStatus::Available {
+            crate_status = CrateStatus::AvailableInNew;
+        }
+
+        self.write_cache("new", package, version, crate_status)?;
+        Ok(crate_status)
     }
 
     pub fn search_generic(
@@ -136,7 +170,7 @@ impl Connection {
         query: &str,
         package: &str,
         version: &str,
-    ) -> Result<bool, Error> {
+    ) -> Result<CrateStatus, Error> {
         let package = package.replace("_", "-");
         let rows = self.sock.query(query, &[&format!("rust-{}", package)])?;
 
@@ -151,10 +185,14 @@ impl Connection {
             // println!("{:?} ({:?}) => {:?}", debversion, version, is_compatible(debversion, version)?);
 
             if is_compatible(debversion, version)? {
-                return Ok(true);
+                return Ok(CrateStatus::Available);
             }
         }
 
-        Ok(false)
+        if rows.len() > 0 {
+            return Ok(CrateStatus::Outdated);
+        }
+
+        Ok(CrateStatus::Missing)
     }
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -57,12 +57,8 @@ impl<'a> fmt::Display for Display<'a> {
                 Chunk::Package => {
                     let pkg = format!("{} v{}", self.package.name, self.package.version);
                     if let Some(deb) = &self.package.debinfo {
-                        if deb.in_unstable {
-                            write!(fmt, "{} (in debian)", pkg.green())?;
-                        } else if deb.in_new {
-                            write!(fmt, "{} (in debian NEW queue)", pkg.blue())?;
-                        } else if deb.outdated {
-                            write!(fmt, "{} (outdated)", pkg.yellow())?;
+                        if deb.in_debian() {
+                            write!(fmt, "{} ({})", pkg.green(), deb)?;
                         } else {
                             write!(fmt, "{}", pkg)?;
                         }


### PR DESCRIPTION
This moves the triple-bool `DebianInfo` struct into a stricter `CrateStatus` enum and uses that throughout the db query interface to communicate the result.

Additional changes:
* move the status string into a `std::fmt::Display` implementation for `CrateStatus`. This allows a uniform representation everywhere.
* ignore I/O and deserialization errors when trying to read the cache. This allows for a silent upgrade of the cache format, discarding entries of previous versions. If the cache target has permissions issues, this should show up when trying to write to it.

Output for this commit of `cargo-debstatus`:

```
cargo-debstatus v0.4.0 (/home/david/github/cargo-debstatus)
├── anyhow v1.0.43 (in debian)
├── cargo_metadata v0.14.0 (in debian)
├── colored v2.0.0 (in debian)
├── crossbeam-channel v0.5.1 (in debian)
├── dirs v3.0.2 (outdated)
├── env_logger v0.9.0 (in debian)
├── indicatif v0.16.2 (in debian)
├── log v0.4.14 (in debian)
├── petgraph v0.6.0 (in debian)
├── postgres v0.19.1
│   ├── bytes v1.0.1 (in debian)
│   ├── fallible-iterator v0.2.0 (in debian)
│   ├── futures v0.3.16 (in debian)
│   ├── log v0.4.14 (in debian)
│   ├── tokio v1.10.0 (in debian)
│   └── tokio-postgres v0.7.2
│       ├── async-trait v0.1.51 (in debian)
│       ├── byteorder v1.4.3 (in debian)
│       ├── bytes v1.0.1 (in debian)
│       ├── fallible-iterator v0.2.0 (in debian)
│       ├── futures v0.3.16 (in debian)
│       ├── log v0.4.14 (in debian)
│       ├── parking_lot v0.11.1 (outdated)
│       ├── percent-encoding v2.1.0 (in debian)
│       ├── phf v0.8.0 (outdated)
│       ├── pin-project-lite v0.2.7 (in debian)
│       ├── postgres-protocol v0.6.1 (in debian)
│       ├── postgres-types v0.2.1 (in debian)
│       ├── socket2 v0.4.1 (in debian)
│       ├── tokio v1.10.0 (in debian)
│       └── tokio-util v0.6.7 (outdated)
├── semver v1.0.4 (in debian)
├── serde v1.0.127 (in debian)
├── serde_json v1.0.66 (in debian)
└── structopt v0.3.22 (in debian)
```

diff against output on `main`:

```diff
--- /home/david/tmp/old	2022-10-05 20:07:57.456498093 +0100
+++ /home/david/tmp/new	2022-10-05 20:06:13.776008456 +0100
@@ -3,8 +3,7 @@
 ├── cargo_metadata v0.14.0 (in debian)
 ├── colored v2.0.0 (in debian)
 ├── crossbeam-channel v0.5.1 (in debian)
-├── dirs v3.0.2
-│   └── dirs-sys v0.3.6 (in debian)
+├── dirs v3.0.2 (outdated)
 ├── env_logger v0.9.0 (in debian)
 ├── indicatif v0.16.2 (in debian)
 ├── log v0.4.14 (in debian)
@@ -22,30 +21,15 @@
 │       ├── fallible-iterator v0.2.0 (in debian)
 │       ├── futures v0.3.16 (in debian)
 │       ├── log v0.4.14 (in debian)
-│       ├── parking_lot v0.11.1
-│       │   ├── instant v0.1.10 (in debian)
-│       │   ├── lock_api v0.4.4 (in debian)
-│       │   └── parking_lot_core v0.8.3
-│       │       ├── cfg-if v1.0.0 (in debian)
-│       │       ├── instant v0.1.10 (in debian)
-│       │       ├── libc v0.2.99 (in debian)
-│       │       └── smallvec v1.6.1 (in debian)
+│       ├── parking_lot v0.11.1 (outdated)
 │       ├── percent-encoding v2.1.0 (in debian)
-│       ├── phf v0.8.0
-│       │   └── phf_shared v0.8.0
-│       │       └── siphasher v0.3.6 (in debian)
+│       ├── phf v0.8.0 (outdated)
 │       ├── pin-project-lite v0.2.7 (in debian)
 │       ├── postgres-protocol v0.6.1 (in debian)
 │       ├── postgres-types v0.2.1 (in debian)
 │       ├── socket2 v0.4.1 (in debian)
 │       ├── tokio v1.10.0 (in debian)
-│       └── tokio-util v0.6.7
-│           ├── bytes v1.0.1 (in debian)
-│           ├── futures-core v0.3.16 (in debian)
-│           ├── futures-sink v0.3.16 (in debian)
-│           ├── log v0.4.14 (in debian)
-│           ├── pin-project-lite v0.2.7 (in debian)
-│           └── tokio v1.10.0 (in debian)
+│       └── tokio-util v0.6.7 (outdated)
 ├── semver v1.0.4 (in debian)
 ├── serde v1.0.127 (in debian)
 ├── serde_json v1.0.66 (in debian)
```