### PR TITLE
Improve handling of semver-incompatible crates/packages

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -16,22 +16,22 @@ pub struct CacheEntry {
 }
 
 // TODO: also use this for outdated check(?)
-fn is_compatible(a: &str, b: &str) -> Result<bool, Error> {
-    let a = a.replace('~', "-");
-    let b = b.replace('~', "-");
+fn is_compatible(debversion: &str, crateversion: &str) -> Result<bool, Error> {
+    let debversion = debversion.replace('~', "-");
+    let crateversion = crateversion.replace('~', "-");
 
-    let a = Version::parse(&a)?;
-    let b = Version::parse(&b)?;
+    let debversion = Version::parse(&debversion)?;
+    let crateversion = Version::parse(&crateversion)?;
 
-    if a.major > 0 || b.major > 0 {
-        return Ok(a.major == b.major);
+    if debversion.major > 0 || crateversion.major > 0 {
+        return Ok(debversion.major == crateversion.major);
     }
 
-    if a.minor > 0 || b.minor > 0 {
-        return Ok(a.minor == b.minor);
+    if debversion.minor > 0 || crateversion.minor > 0 {
+        return Ok(debversion.minor == crateversion.minor);
     }
 
-    Ok(a.patch == b.patch)
+    Ok(debversion.patch == crateversion.patch)
 }
 
 pub struct Connection {

--- a/src/debian.rs
+++ b/src/debian.rs
@@ -61,9 +61,9 @@ fn run_task(db: &mut Connection, pkg: Pkg) -> Result<DebianInfo> {
         outdated: false,
     };
 
-    if db.search(&pkg.name, &pkg.version.to_string()).unwrap() {
+    if db.search(&pkg.name, &pkg.version).unwrap() {
         deb.in_unstable = true;
-    } else if db.search_new(&pkg.name, &pkg.version.to_string()).unwrap() {
+    } else if db.search_new(&pkg.name, &pkg.version).unwrap() {
         deb.in_new = true;
     }
 


### PR DESCRIPTION
Since Debian may have multiple semver-incompatible packages, debstatus needs to account for that when searching for packages.

Update the UDD searches to search for both `rust-<crate>` and `rust-<crate>-<semver>`.

While implementing this, I also noticed that `is_compatible()` wasn't checking versions properly.  For example, a crate version of 0.1.1 is reported as packaged when the Debian package is version 0.1.0.  Therefore, I've updated the version handling to use `semver::VersionReq` to check compatibility.

Here's a diff of the output, as of today, for alacritty v0.12.2:

```diff
--- /home/jamessan/before.txt	2023-07-03 00:06:11.384886191 -0400
+++ /home/jamessan/after.txt	2023-07-03 00:06:57.120747116 -0400
@@ -1,29 +1,58 @@
 alacritty v0.12.2 (/home/jamessan/src/github.com/alacritty/alacritty)
-├── alacritty_config v0.1.1 (in debian) (/home/jamessan/src/github.com/alacritty/alacritty_config)
-├── alacritty_config_derive v0.2.1 (in debian) (/home/jamessan/src/github.com/alacritty/alacritty_config_derive)
+├── alacritty_config v0.1.1 (/home/jamessan/src/github.com/alacritty/alacritty_config)
+│   ├── log v0.4.17 (in debian)
+│   ├── serde v1.0.144 (in debian)
+│   └── serde_yaml v0.8.26 (in debian)
+├── alacritty_config_derive v0.2.1 (/home/jamessan/src/github.com/alacritty/alacritty_config_derive)
+│   ├── proc-macro2 v1.0.43 (in debian)
+│   ├── quote v1.0.21 (in debian)
+│   └── syn v1.0.99 (in debian)
+│   [dev-dependencies]
+│   ├── alacritty_config v0.1.1 (/home/jamessan/src/github.com/alacritty/alacritty_config)
+│   │   ├── log v0.4.17 (in debian)
+│   │   ├── serde v1.0.144 (in debian)
+│   │   └── serde_yaml v0.8.26 (in debian)
+│   ├── log v0.4.17 (in debian)
+│   ├── serde v1.0.144 (in debian)
+│   └── serde_yaml v0.8.26 (in debian)
 ├── alacritty_terminal v0.19.1 (/home/jamessan/src/github.com/alacritty/alacritty_terminal)
-│   ├── alacritty_config v0.1.1 (in debian) (/home/jamessan/src/github.com/alacritty/alacritty_config)
-│   ├── alacritty_config_derive v0.2.1 (in debian) (/home/jamessan/src/github.com/alacritty/alacritty_config_derive)
+│   ├── alacritty_config v0.1.1 (/home/jamessan/src/github.com/alacritty/alacritty_config)
+│   │   ├── log v0.4.17 (in debian)
+│   │   ├── serde v1.0.144 (in debian)
+│   │   └── serde_yaml v0.8.26 (in debian)
+│   ├── alacritty_config_derive v0.2.1 (/home/jamessan/src/github.com/alacritty/alacritty_config_derive)
+│   │   ├── proc-macro2 v1.0.43 (in debian)
+│   │   ├── quote v1.0.21 (in debian)
+│   │   └── syn v1.0.99 (in debian)
+│   │   [dev-dependencies]
+│   │   ├── alacritty_config v0.1.1 (/home/jamessan/src/github.com/alacritty/alacritty_config)
+│   │   │   ├── log v0.4.17 (in debian)
+│   │   │   ├── serde v1.0.144 (in debian)
+│   │   │   └── serde_yaml v0.8.26 (in debian)
+│   │   ├── log v0.4.17 (in debian)
+│   │   ├── serde v1.0.144 (in debian)
+│   │   └── serde_yaml v0.8.26 (in debian)
 │   ├── base64 v0.13.0
-│   ├── bitflags v1.3.2
+│   ├── bitflags v1.3.2 (in debian)
 │   ├── dirs v4.0.0 (in debian)
 │   ├── libc v0.2.132 (in debian)
 │   ├── log v0.4.17 (in debian)
-│   ├── mio v0.6.23
-│   │   ├── cfg-if v0.1.10
-│   │   ├── iovec v0.1.4 (in debian)
-│   │   ├── libc v0.2.132 (in debian)
+│   ├── mio v0.6.23 (in debian)
+│   ├── mio-extras v2.0.6
+│   │   ├── lazycell v1.3.0 (in debian)
 │   │   ├── log v0.4.17 (in debian)
-│   │   ├── net2 v0.2.37 (in debian)
-│   │   └── slab v0.4.7 (in debian)
-│   ├── mio-extras v2.0.6 (in debian)
+│   │   ├── mio v0.6.23 (in debian)
+│   │   └── slab v0.4.7
+│   │       [build-dependencies]
+│   │       └── autocfg v1.1.0 (in debian)
 │   ├── nix v0.24.2
-│   │   ├── bitflags v1.3.2
+│   │   ├── bitflags v1.3.2 (in debian)
 │   │   ├── cfg-if v1.0.0 (in debian)
 │   │   ├── libc v0.2.132 (in debian)
 │   │   └── memoffset v0.6.5 (in debian)
 │   ├── parking_lot v0.12.1 (in debian)
-│   ├── regex-automata v0.1.10 (in debian)
+│   ├── regex-automata v0.1.10
+│   │   └── regex-syntax v0.6.27 (in debian)
 │   ├── serde v1.0.144 (in debian)
 │   ├── serde_yaml v0.8.26 (in debian)
 │   ├── signal-hook v0.3.14 (in debian)
@@ -32,37 +61,46 @@
 │   └── vte v0.10.1 (in debian)
 │   [dev-dependencies]
 │   └── serde_json v1.0.85 (in debian)
-├── bitflags v1.3.2
-├── clap v3.2.21
-│   ├── atty v0.2.14 (in debian)
-│   ├── bitflags v1.3.2
-│   ├── clap_derive v3.2.18
-│   │   ├── heck v0.4.0 (in debian)
-│   │   ├── proc-macro-error v1.0.4 (in debian)
-│   │   ├── proc-macro2 v1.0.43 (in debian)
-│   │   ├── quote v1.0.21 (in debian)
-│   │   └── syn v1.0.99
-│   │       ├── proc-macro2 v1.0.43 (in debian)
-│   │       ├── quote v1.0.21 (in debian)
-│   │       └── unicode-ident v1.0.4 (in debian)
-│   ├── clap_lex v0.2.4
-│   │   └── os_str_bytes v6.3.0 (in debian)
-│   ├── indexmap v1.9.1 (in debian)
-│   ├── once_cell v1.14.0 (in debian)
-│   ├── strsim v0.10.0 (in debian)
-│   ├── termcolor v1.1.3 (in debian)
-│   └── textwrap v0.15.1
-├── copypasta v0.8.2 (in debian)
-├── crossfont v0.5.1 (in debian)
+├── bitflags v1.3.2 (in debian)
+├── clap v3.2.21 (in debian)
+├── copypasta v0.8.2
+│   ├── smithay-clipboard v0.6.6 (in debian)
+│   └── x11-clipboard v0.7.1
+│       └── x11rb v0.10.1
+│           ├── gethostname v0.2.3
+│           │   └── libc v0.2.132 (in debian)
+│           ├── nix v0.24.2
+│           │   ├── bitflags v1.3.2 (in debian)
+│           │   ├── cfg-if v1.0.0 (in debian)
+│           │   ├── libc v0.2.132 (in debian)
+│           │   └── memoffset v0.6.5 (in debian)
+│           └── x11rb-protocol v0.10.0
+│               └── nix v0.24.2
+│                   ├── bitflags v1.3.2 (in debian)
+│                   ├── cfg-if v1.0.0 (in debian)
+│                   ├── libc v0.2.132 (in debian)
+│                   └── memoffset v0.6.5 (in debian)
+├── crossfont v0.5.1
+│   ├── foreign-types v0.5.0 (in debian)
+│   ├── freetype-rs v0.26.0 (in debian)
+│   ├── libc v0.2.132 (in debian)
+│   ├── log v0.4.17 (in debian)
+│   └── servo-fontconfig v0.5.1 (in debian)
+│   [build-dependencies]
+│   └── pkg-config v0.3.25 (in debian)
 ├── dirs v4.0.0 (in debian)
 ├── fnv v1.0.7 (in debian)
 ├── glutin v0.30.9
-│   ├── bitflags v1.3.2
+│   ├── bitflags v1.3.2 (in debian)
 │   ├── glutin_egl_sys v0.5.0
 │   │   [build-dependencies]
 │   │   └── gl_generator v0.14.0 (in debian)
 │   ├── glutin_glx_sys v0.4.0
-│   │   └── x11-dl v2.20.0 (in debian)
+│   │   └── x11-dl v2.20.0
+│   │       ├── lazy_static v1.4.0 (in debian)
+│   │       └── libc v0.2.132 (in debian)
+│   │       [build-dependencies]
+│   │       └── pkg-config v0.3.25 (in debian)
 │   │   [build-dependencies]
 │   │   └── gl_generator v0.14.0 (in debian)
 │   ├── libloading v0.7.3 (in debian)
@@ -74,12 +112,23 @@
 │   │   └── log v0.4.17 (in debian)
 │   │   [build-dependencies]
 │   │   └── pkg-config v0.3.25 (in debian)
-│   └── x11-dl v2.20.0 (in debian)
+│   └── x11-dl v2.20.0
+│       ├── lazy_static v1.4.0 (in debian)
+│       └── libc v0.2.132 (in debian)
+│       [build-dependencies]
+│       └── pkg-config v0.3.25 (in debian)
 │   [build-dependencies]
 │   └── cfg_aliases v0.1.1 (in debian)
 ├── libc v0.2.132 (in debian)
 ├── log v0.4.17 (in debian)
-├── notify v5.1.0 (in debian)
+├── notify v5.1.0
+│   ├── bitflags v1.3.2 (in debian)
+│   ├── crossbeam-channel v0.5.6 (in debian)
+│   ├── filetime v0.2.17 (in debian)
+│   ├── inotify v0.9.6 (in debian)
+│   ├── libc v0.2.132 (in debian)
+│   ├── mio v0.8.4 (in debian)
+│   └── walkdir v2.3.2 (in debian)
 ├── once_cell v1.14.0 (in debian)
 ├── parking_lot v0.12.1 (in debian)
 ├── png v0.17.6 (in debian)
@@ -88,9 +137,9 @@
 ├── serde_json v1.0.85 (in debian)
 ├── serde_yaml v0.8.26 (in debian)
 ├── unicode-width v0.1.10 (in debian)
-├── wayland-client v0.29.5 (in debian)
+├── wayland-client v0.29.5 (in debian NEW queue)
 ├── winit v0.28.6
-│   ├── bitflags v1.3.2
+│   ├── bitflags v1.3.2 (in debian)
 │   ├── instant v0.1.12 (in debian)
 │   ├── libc v0.2.132 (in debian)
 │   ├── log v0.4.17 (in debian)
@@ -99,42 +148,48 @@
 │   ├── percent-encoding v2.2.0 (in debian)
 │   ├── raw-window-handle v0.5.0 (in debian)
 │   ├── sctk-adwaita v0.5.4
-│   │   ├── crossfont v0.5.1 (in debian)
+│   │   ├── crossfont v0.5.1
+│   │   │   ├── foreign-types v0.5.0 (in debian)
+│   │   │   ├── freetype-rs v0.26.0 (in debian)
+│   │   │   ├── libc v0.2.132 (in debian)
+│   │   │   ├── log v0.4.17 (in debian)
+│   │   │   └── servo-fontconfig v0.5.1 (in debian)
+│   │   │   [build-dependencies]
+│   │   │   └── pkg-config v0.3.25 (in debian)
 │   │   ├── log v0.4.17 (in debian)
-│   │   ├── memmap2 v0.5.10 (in debian)
+│   │   ├── memmap2 v0.5.10
+│   │   │   └── libc v0.2.132 (in debian)
 │   │   ├── smithay-client-toolkit v0.16.0 (in debian)
 │   │   └── tiny-skia v0.8.3 (in debian)
 │   ├── serde v1.0.144 (in debian)
 │   ├── smithay-client-toolkit v0.16.0 (in debian)
-│   ├── wayland-client v0.29.5 (in debian)
-│   ├── wayland-commons v0.29.5 (in debian)
-│   ├── wayland-protocols v0.29.5 (in debian)
-│   └── x11-dl v2.20.0 (in debian)
+│   ├── wayland-client v0.29.5 (in debian NEW queue)
+│   ├── wayland-commons v0.29.5
+│   │   ├── nix v0.24.2
+│   │   │   ├── bitflags v1.3.2 (in debian)
+│   │   │   ├── cfg-if v1.0.0 (in debian)
+│   │   │   ├── libc v0.2.132 (in debian)
+│   │   │   └── memoffset v0.6.5 (in debian)
+│   │   ├── once_cell v1.14.0 (in debian)
+│   │   ├── smallvec v1.9.0 (in debian)
+│   │   └── wayland-sys v0.29.5 (in debian NEW queue)
+│   ├── wayland-protocols v0.29.5 (in debian NEW queue)
+│   └── x11-dl v2.20.0
+│       ├── lazy_static v1.4.0 (in debian)
+│       └── libc v0.2.132 (in debian)
+│       [build-dependencies]
+│       └── pkg-config v0.3.25 (in debian)
 │   [build-dependencies]
 │   ├── cfg_aliases v0.1.1 (in debian)
-│   └── wayland-scanner v0.29.5 (in debian)
-├── x11-dl v2.20.0 (in debian)
+│   └── wayland-scanner v0.29.5 (in debian NEW queue)
+├── x11-dl v2.20.0
+│   ├── lazy_static v1.4.0 (in debian)
+│   └── libc v0.2.132 (in debian)
+│   [build-dependencies]
+│   └── pkg-config v0.3.25 (in debian)
 └── xdg v2.4.1 (in debian)
 [build-dependencies]
 └── gl_generator v0.14.0 (in debian)
 [dev-dependencies]
 └── clap_complete v3.2.5
-    └── clap v3.2.21
-        ├── atty v0.2.14 (in debian)
-        ├── bitflags v1.3.2
-        ├── clap_derive v3.2.18
-        │   ├── heck v0.4.0 (in debian)
-        │   ├── proc-macro-error v1.0.4 (in debian)
-        │   ├── proc-macro2 v1.0.43 (in debian)
-        │   ├── quote v1.0.21 (in debian)
-        │   └── syn v1.0.99
-        │       ├── proc-macro2 v1.0.43 (in debian)
-        │       ├── quote v1.0.21 (in debian)
-        │       └── unicode-ident v1.0.4 (in debian)
-        ├── clap_lex v0.2.4
-        │   └── os_str_bytes v6.3.0 (in debian)
-        ├── indexmap v1.9.1 (in debian)
-        ├── once_cell v1.14.0 (in debian)
-        ├── strsim v0.10.0 (in debian)
-        ├── termcolor v1.1.3 (in debian)
-        └── textwrap v0.15.1
+    └── clap v3.2.21 (in debian)
```