### PR TITLE
Version check improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --include-ignored
     - name: Run debstatus on itself
       run: cargo run -- debstatus
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -9,13 +9,26 @@ use std::time::{Duration, SystemTime};
 const POSTGRES: &str = "postgresql://udd-mirror:udd-mirror@udd-mirror.debian.net/udd";
 const CACHE_EXPIRE: Duration = Duration::from_secs(90 * 60);
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub enum PkgStatus {
+    NotFound,
+    Outdated,
+    Compatible,
+    Found,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PkgInfo {
+    pub status: PkgStatus,
+    pub version: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CacheEntry {
     pub from: SystemTime,
-    pub found: bool,
+    pub info: PkgInfo,
 }
 
-// TODO: also use this for outdated check(?)
 fn is_compatible(debversion: &str, crateversion: &VersionReq) -> Result<bool, Error> {
     let debversion = debversion.replace('~', "-");
     let debversion = Version::parse(&debversion)?;
@@ -56,20 +69,28 @@ impl Connection {
         target: &str,
         package: &str,
         version: &Version,
-    ) -> Result<Option<bool>, Error> {
+    ) -> Result<Option<PkgInfo>, Error> {
         let path = self.cache_path(target, package, version);
 
         if !path.exists() {
             return Ok(None);
         }
 
-        let buf = fs::read(path)?;
-        let cache: CacheEntry = serde_json::from_slice(&buf)?;
+        let buf = fs::read(&path)?;
+        // If the cache entry can't be deserialized, it's probably using an old
+        // entry format, so let's discard it
+        let cache: CacheEntry = match serde_json::from_slice(&buf) {
+            Ok(e) => e,
+            _ => {
+                fs::remove_file(path)?;
+                return Ok(None);
+            }
+        };
 
         if SystemTime::now().duration_since(cache.from)? > CACHE_EXPIRE {
             Ok(None)
         } else {
-            Ok(Some(cache.found))
+            Ok(Some(cache.info))
         }
     }
 
@@ -78,49 +99,49 @@ impl Connection {
         target: &str,
         package: &str,
         version: &Version,
-        found: bool,
+        info: &PkgInfo,
     ) -> Result<(), Error> {
         let cache = CacheEntry {
             from: SystemTime::now(),
-            found,
+            info: info.clone(),
         };
         let buf = serde_json::to_vec(&cache)?;
         fs::write(self.cache_path(target, package, version), buf)?;
         Ok(())
     }
 
-    pub fn search(&mut self, package: &str, version: &Version) -> Result<bool, Error> {
-        if let Some(found) = self.check_cache("sid", package, version)? {
-            return Ok(found);
+    pub fn search(&mut self, package: &str, version: &Version) -> Result<PkgInfo, Error> {
+        if let Some(info) = self.check_cache("sid", package, version)? {
+            return Ok(info);
         }
 
         // config.shell().status("Querying", format!("sid: {}", package))?;
         info!("Querying -> sid: {}", package);
-        let found = self.search_generic(
+        let info = self.search_generic(
             "SELECT version::text FROM sources WHERE source in ($1, $2) AND release='sid';",
             package,
             version,
         )?;
 
-        self.write_cache("sid", package, version, found)?;
-        Ok(found)
+        self.write_cache("sid", package, version, &info)?;
+        Ok(info)
     }
 
-    pub fn search_new(&mut self, package: &str, version: &Version) -> Result<bool, Error> {
-        if let Some(found) = self.check_cache("new", package, version)? {
-            return Ok(found);
+    pub fn search_new(&mut self, package: &str, version: &Version) -> Result<PkgInfo, Error> {
+        if let Some(info) = self.check_cache("new", package, version)? {
+            return Ok(info);
         }
 
         // config.shell().status("Querying", format!("new: {}", package))?;
         info!("Querying -> new: {}", package);
-        let found = self.search_generic(
+        let info = self.search_generic(
             "SELECT version::text FROM new_sources WHERE source in ($1, $2);",
             package,
             version,
         )?;
 
-        self.write_cache("new", package, version, found)?;
-        Ok(found)
+        self.write_cache("new", package, version, &info)?;
+        Ok(info)
     }
 
     pub fn search_generic(
@@ -128,7 +149,11 @@ impl Connection {
         query: &str,
         package: &str,
         version: &Version,
-    ) -> Result<bool, Error> {
+    ) -> Result<PkgInfo, Error> {
+        let mut info = PkgInfo {
+            status: PkgStatus::NotFound,
+            version: String::new(),
+        };
         let package = package.replace('_', "-");
         let semver_version = if version.major == 0 {
             if version.minor == 0 {
@@ -160,12 +185,20 @@ impl Connection {
 
             // println!("{:?} ({:?}) => {:?}", debversion, version, is_compatible(debversion, version)?);
 
-            if is_compatible(debversion, &version)? || is_compatible(debversion, &semver_version)? {
-                return Ok(true);
+            if is_compatible(debversion, &version)? {
+                info.version = debversion.to_string();
+                info.status = PkgStatus::Found;
+                return Ok(info);
+            } else if is_compatible(debversion, &semver_version)? {
+                info.version = debversion.to_string();
+                info.status = PkgStatus::Compatible;
+            } else if info.status == PkgStatus::NotFound {
+                info.version = debversion.to_string();
+                info.status = PkgStatus::Outdated;
             }
         }
 
-        Ok(false)
+        Ok(info)
     }
 }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -58,11 +58,29 @@ impl<'a> fmt::Display for Display<'a> {
                     let pkg = format!("{} v{}", self.package.name, self.package.version);
                     if let Some(deb) = &self.package.debinfo {
                         if deb.in_unstable {
-                            write!(fmt, "{} (in debian)", pkg.green())?;
+                            if deb.compatible {
+                                write!(
+                                    fmt,
+                                    "{} ({} in debian)",
+                                    pkg.green(),
+                                    deb.version.yellow()
+                                )?;
+                            } else {
+                                write!(fmt, "{} (in debian)", pkg.green())?;
+                            }
                         } else if deb.in_new {
-                            write!(fmt, "{} (in debian NEW queue)", pkg.blue())?;
+                            if deb.compatible {
+                                write!(
+                                    fmt,
+                                    "{} ({} in debian NEW queue)",
+                                    pkg.blue(),
+                                    deb.version.yellow()
+                                )?;
+                            } else {
+                                write!(fmt, "{} (in debian NEW queue)", pkg.blue())?;
+                            }
                         } else if deb.outdated {
-                            write!(fmt, "{} (outdated)", pkg.yellow())?;
+                            write!(fmt, "{} (outdated, {})", pkg.red(), deb.version)?;
                         } else {
                             write!(fmt, "{pkg}")?;
                         }


### PR DESCRIPTION
This PR addresses 2 distinct "issues":
* it fixes #31 by adding a check on a likely-compatible version in case the exact check fails
* it implements "outdated" reporting and adds a new "compatible" status (for crates not fully up-to-date, but likely compatible according to semver) -- reporting the Debian package version in both cases so it's more obvious/useful to the user

Those are split in 2 separate commits in case you only want to cherry-pick the first part.