### PR TITLE
Annotate duplicate entries with a (*)

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -206,6 +206,13 @@ fn print_package<'a>(
         Prefix::None => {}
     }
 
+    if !all && visited_deps.contains(&package.id) {
+        println!("{} (*)", format.display(package));
+        return;
+    }
+
+    visited_deps.insert(&package.id);
+
     println!("{}", format.display(package));
 
     if package.in_debian() {


### PR DESCRIPTION
Rather than re-traverse the entries, which can lead to [pathological cases] of recursion, keep track of which PackageIds have been shown. When encountering a duplicate PackageId, indicate this with "(*)" as "cargo tree" does, and return early.

[pathological cases]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1052650