### PR TITLE
Never collapse dependencies of root crate, even if packaged

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -214,7 +214,7 @@ fn print_package<'a>(
     let pkg_status_s = format.display(package).to_string();
     println!("{}{}", treeline, pkg_status_s);
 
-    if !all && !package.show_dependencies() {
+    if !all && !package.show_dependencies() && !levels_continue.is_empty() {
         return;
     }
 


### PR DESCRIPTION
I've previously edited the version in Cargo.toml to cause a mismatch with what's already in Debian, so I can view the dependency tree again, this change removes the need for this workaround:

Before:
```
% cargo debstatus
    sniffglue v0.16.1 (in debian) (/home/.../sniffglue)
```
After:
```
% cargo debstatus 
    sniffglue v0.16.1 (in debian) (/home/.../sniffglue)
    ├── ansi_term v0.12.1 (in debian)
    ├── anyhow v1.0.87 (1.0.86 in debian)
    ├── bstr v1.10.0 (1.7.0 in debian)
    ├── clap v4.5.17 (4.5.16 in debian)
    ├── clap_complete v4.5.26 (4.5.18 in debian)
    ├── data-encoding v2.6.0 (2.5.0 in debian)
    ├── dhcp4r v0.2.3 (in debian)
    ├── dirs-next v2.0.0 (in debian)
    ├── dns-parser v0.8.0 (in debian)
 ⌛ ├── env_logger v0.11.5 (outdated, 0.10.2 in debian)
    │   ├── anstream v0.6.15 (in debian)
    │   ├── anstyle v1.0.8 (in debian)
    │   ├── env_filter v0.1.2 (in debian)
    │   ├── humantime v2.1.0 (in debian)
    │   └── log v0.4.22 (in debian)
    ├── httparse v1.9.4 (1.8.0 in debian)
    ├── libc v0.2.158 (in debian)
    ├── log v0.4.22 (in debian)
    ├── nix v0.29.0 (in debian)
    ├── nom v7.1.3 (in debian)
    ├── num_cpus v1.16.0 (in debian)
    ├── pcap-sys v0.1.3 (in debian)
    ├── pktparse v0.7.1 (in debian)
    ├── serde v1.0.210 (in debian)
    ├── serde_json v1.0.128 (in debian)
    ├── sha2 v0.10.8 (in debian)
    ├── syscallz v0.17.0 (in debian)
    ├── tls-parser v0.12.1 (in debian)
    ├── toml v0.8.19 (in debian)
    └── uzers v0.12.1 (in debian)
    [dev-dependencies]
 🔴 └── boxxy v0.13.1
        ├── anyhow v1.0.87 (1.0.86 in debian)
 ⌛     ├── base64 v0.13.1 (outdated, 0.22.1 in debian)
 🔴     ├── bufstream v0.1.4
        ├── caps v0.5.5 (in debian)
        ├── cfg-if v1.0.0 (in debian)
        ├── clap v3.2.25 (in debian)
 🔴     ├── close_fds v0.3.2
        │   ├── cfg-if v1.0.0 (in debian)
        │   └── libc v0.2.158 (in debian)
 ⌛     ├── errno v0.2.8 (outdated, 0.3.8 in debian)
        │   └── libc v0.2.158 (in debian)
        ├── libc v0.2.158 (in debian)
        ├── log v0.4.22 (in debian)
 ⌛     ├── nix v0.24.3 (outdated, 0.29.0 in debian)
        │   ├── bitflags v1.3.2 (in debian)
        │   ├── cfg-if v1.0.0 (in debian)
        │   ├── libc v0.2.158 (in debian)
 ⌛     │   └── memoffset v0.6.5 (outdated, 0.8.0 in debian)
        │       [build-dependencies]
        │       └── autocfg v1.3.0 (1.1.0 in debian)
        ├── regex v1.10.6 (in debian)
 ⌛     └── rustyline v10.1.1 (outdated, 13.0.0 in debian)
            ├── bitflags v1.3.2 (in debian)
            ├── cfg-if v1.0.0 (in debian)
            ├── dirs-next v2.0.0 (in debian)
            ├── fd-lock v3.0.13 (in debian)
            ├── libc v0.2.158 (in debian)
            ├── log v0.4.22 (in debian)
            ├── memchr v2.7.4 (in debian)
 ⌛         ├── nix v0.25.1 (outdated, 0.29.0 in debian)
            │   ├── bitflags v1.3.2 (in debian)
            │   ├── cfg-if v1.0.0 (in debian)
            │   └── libc v0.2.158 (in debian)
            │   [build-dependencies]
            │   └── autocfg v1.3.0 (1.1.0 in debian)
            ├── radix_trie v0.2.1 (in debian)
            ├── unicode-segmentation v1.11.0 (in debian)
            ├── unicode-width v0.1.13 (in debian)
            └── utf8parse v0.2.2 (0.2.1 in debian)
```