### PR TITLE
Workspace support

### DIFF
--- a/cargo-debstatus.1
+++ b/cargo-debstatus.1
@@ -67,6 +67,10 @@ Skip dev dependencies
 \f[B]--manifest-path\f[R] <PATH>
 Path to Cargo.toml
 .TP
+\f[B]-w\f[R], \f[B]--collapse-workspace\f[R]
+Hide the dependency trees of workspace members which are dependencies
+of other members
+.TP
 \f[B]-i\f[R], \f[B]--invert\f[R]
 Invert the tree direction
 .TP

--- a/src/args.rs
+++ b/src/args.rs
@@ -42,6 +42,9 @@ pub struct Args {
     #[clap(long = "manifest-path", value_name = "PATH")]
     /// Path to Cargo.toml
     pub manifest_path: Option<PathBuf>,
+    #[clap(long = "collapse-workspace", short = 'w')]
+    /// Hide the dependency trees of workspace members which are dependencies of other members
+    pub collapse_workspace: bool,
     #[clap(long = "invert", short = 'i')]
     /// Invert the tree direction
     pub invert: bool,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -75,9 +75,15 @@ pub fn print(args: &Args, graph: &Graph) -> Result<(), Error> {
     } else {
         let root = match &args.package {
             Some(package) => find_package(package, graph)?,
-            None => graph.root.as_ref().ok_or_else(|| {
-                anyhow!("this command requires running against an actual package in this workspace")
-            })?,
+            None => {
+                if graph.roots.len() == 1 {
+                    &graph.roots[0]
+                } else {
+                    return Err(anyhow!(
+                        "this command requires running against an actual package in this workspace"
+                    ));
+                }
+            }
         };
         let root = &graph.graph[graph.nodes[root]];
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -73,23 +73,20 @@ pub fn print(args: &Args, graph: &Graph) -> Result<(), Error> {
             )?;
         }
     } else {
-        let root = match &args.package {
-            Some(package) => find_package(package, graph)?,
-            None => {
-                if graph.roots.len() == 1 {
-                    &graph.roots[0]
-                } else {
-                    return Err(anyhow!(
-                        "this command requires running against an actual package in this workspace"
-                    ));
-                }
-            }
+        let roots = match &args.package {
+            Some(package) => vec![find_package(package, graph)?],
+            None => graph.roots.iter().collect(),
         };
-        let root = &graph.graph[graph.nodes[root]];
+        for (i, root) in roots.into_iter().enumerate() {
+            if i != 0 {
+                println!();
+            }
 
-        print_tree(
-            graph, root, &format, direction, symbols, prefix, args.all, args.json,
-        )?;
+            let root = &graph.graph[graph.nodes[root]];
+            print_tree(
+                graph, root, &format, direction, symbols, prefix, args.all, args.json,
+            )?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
In my opinion, workspace support means implementing three output modes:

1. single-member tree (already implemented, the `-p` option)
2. trees for every workspace member, all at once
3. trees for all independent workspace member, all at once (i.e. like 2. but discarding trees of dependencies of other members)

This PR implements 2 and 3. The commit messages should explain the changes in sufficient detail. I am marking this as a draft both because I'd like to receive some feedback from the debstatus maintainers and from the Rust Team, and because I haven't tested these changes (yet) in combination with the various flags. For testing I used the resvg workspace.