### PR TITLE
feat: Differentiate between "outdated" and "newer" in Debian

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "strip-ansi-escapes",
  "tempfile",
 ]
 
@@ -1082,6 +1083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1268,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = "1.0"
 
 [dev-dependencies]
 tempfile = "3"
+strip-ansi-escapes = "0.2"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
 use postgres::types::ToSql;
 use postgres::{Client as LiveClient, NoTls};
-use semver::{Version, VersionReq};
+use semver::{Comparator, Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -15,6 +15,7 @@ pub enum PkgStatus {
     NotFound,
     Outdated,
     Compatible,
+    TooRecent,
     Found,
 }
 
@@ -53,6 +54,44 @@ fn parse_deb_version(debversion: &str) -> Result<Version> {
 fn is_compatible(debversion: &str, crateversion: &VersionReq) -> Result<bool, Error> {
     let debversion = parse_deb_version(debversion)?;
     Ok(crateversion.matches(&debversion))
+}
+
+/// Check if the debian version of a crate is newer than (or as recent as) all
+/// of the bounds mentioned in the crate version requirements.
+fn is_newer(debversion: &str, crateversion: &VersionReq) -> Result<bool, Error> {
+    let debversion = parse_deb_version(debversion)?;
+    Ok(crateversion
+        .comparators
+        .iter()
+        .all(|version_req| matches_greater_or_equal(version_req, &debversion)))
+}
+
+// Check if a given version is greater or equal than the version mentioned in a requirement.
+// Adapted from semver 1.0.26, Apache License, Version 2.0 or MIT license.
+fn matches_greater_or_equal(cmp: &Comparator, ver: &Version) -> bool {
+    if ver.major != cmp.major {
+        return ver.major > cmp.major;
+    }
+
+    match cmp.minor {
+        None => return true,
+        Some(minor) => {
+            if ver.minor != minor {
+                return ver.minor > minor;
+            }
+        }
+    }
+
+    match cmp.patch {
+        None => return true,
+        Some(patch) => {
+            if ver.patch != patch {
+                return ver.patch > patch;
+            }
+        }
+    }
+
+    ver.pre >= cmp.pre
 }
 
 /// Trait which abstracts the SQL database for testing purposes
@@ -289,6 +328,12 @@ impl<C: Client> Connection<C> {
             }
         }
 
+        if info.status == PkgStatus::Outdated {
+            if let Ok(true) = is_newer(&info.version, &version) {
+                info.status = PkgStatus::TooRecent
+            }
+        }
+
         debug!("{package} {:?}", info);
         Ok(info)
     }
@@ -298,7 +343,7 @@ impl<C: Client> Connection<C> {
 pub(crate) mod tests {
     use std::{collections::HashMap, path::Path};
 
-    use crate::db::{is_compatible, Connection, PkgStatus, PkgType};
+    use crate::db::{is_compatible, is_newer, Connection, PkgStatus, PkgType};
     use anyhow::anyhow;
     use semver::{Version, VersionReq};
 
@@ -381,6 +426,13 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn is_newer_works() {
+        assert!(is_newer("2.1.0", &VersionReq::parse(">=1.4, <2").unwrap()).unwrap());
+        assert!(!is_newer("1.7.2", &VersionReq::parse(">=1.4, <2").unwrap()).unwrap());
+        assert!(!is_newer("1.2.3", &VersionReq::parse(">=1.4, <2").unwrap()).unwrap());
+    }
+
+    #[test]
     fn find_via_lib_package_name() {
         // crate "usvg" is not packaged from the "resvg" source package, not "rust-usvg"
         let mocked_responses = &[
@@ -438,6 +490,11 @@ pub(crate) mod tests {
         let mocked_responses = &[
             (
                 query,
+                vec!["rust-serde", "rust-serde-0.4"],
+                vec![vec!["1.0.106-1"]],
+            ),
+            (
+                query,
                 vec!["rust-serde", "rust-serde-1"],
                 vec![vec!["1.0.106-1"]],
             ),
@@ -479,6 +536,15 @@ pub(crate) mod tests {
             )
             .unwrap();
         assert_eq!(info.status, PkgStatus::Outdated);
+        let info = db
+            .search_generic(
+                query,
+                "serde",
+                &Version::parse("0.4.5").unwrap(),
+                PkgType::Source,
+            )
+            .unwrap();
+        assert_eq!(info.status, PkgStatus::TooRecent);
         let info = db
             .search_generic(
                 query,

--- a/src/db.rs
+++ b/src/db.rs
@@ -295,13 +295,12 @@ impl<C: Client> Connection<C> {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
+pub(crate) mod tests {
+    use std::{collections::HashMap, path::Path};
 
     use crate::db::{is_compatible, Connection, PkgStatus, PkgType};
     use anyhow::anyhow;
     use semver::{Version, VersionReq};
-    use tempfile::TempDir;
 
     use super::Client;
 
@@ -310,7 +309,7 @@ mod tests {
     /// Mocked SQL query results
     type ResultRows<'a> = Vec<Vec<&'a str>>;
 
-    struct MockClient<'a> {
+    pub(crate) struct MockClient<'a> {
         responses: HashMap<MockedQuery<'a>, ResultRows<'a>>,
     }
 
@@ -336,8 +335,8 @@ mod tests {
         }
     }
 
-    fn mock_connection<'a>(
-        tempdir: &TempDir,
+    pub(crate) fn mock_connection<'a>(
+        tempdir: &'a Path,
         mocked_responses: &'a [(&str, Vec<&str>, ResultRows<'a>)],
     ) -> Connection<MockClient<'a>> {
         let responses = mocked_responses
@@ -352,7 +351,7 @@ mod tests {
             })
             .collect();
         let mock_client = MockClient { responses };
-        let cache_dir = tempdir.path().to_owned();
+        let cache_dir = tempdir.to_owned();
 
         Connection {
             sock: mock_client,
@@ -398,7 +397,7 @@ mod tests {
         ][..];
         let tmpdir =
             tempfile::tempdir().expect("could not create a temporary directory for the cache");
-        let mut db = mock_connection(&tmpdir, mocked_responses);
+        let mut db = mock_connection(tmpdir.path(), mocked_responses);
         let info = db
             .search("usvg", &Version::parse("0.45.0").unwrap(), true)
             .unwrap();
@@ -423,7 +422,7 @@ mod tests {
         ][..];
         let tmpdir =
             tempfile::tempdir().expect("could not create a temporary directory for the cache");
-        let mut db = mock_connection(&tmpdir, mocked_responses);
+        let mut db = mock_connection(tmpdir.path(), mocked_responses);
         let info = db
             .search("vivid", &Version::parse("0.9.0").unwrap(), true)
             .unwrap();
@@ -451,7 +450,7 @@ mod tests {
         ][..];
         let tmpdir =
             tempfile::tempdir().expect("could not create a temporary directory for the cache");
-        let mut db = mock_connection(&tmpdir, mocked_responses);
+        let mut db = mock_connection(tmpdir.path(), mocked_responses);
         let info = db
             .search_generic(
                 query,
@@ -510,7 +509,7 @@ mod tests {
         ][..];
         let tmpdir =
             tempfile::tempdir().expect("could not create a temporary directory for the cache");
-        let mut db = mock_connection(&tmpdir, mocked_responses);
+        let mut db = mock_connection(tmpdir.path(), mocked_responses);
         let info = db
             .search_generic(
                 query,

--- a/src/format/human.rs
+++ b/src/format/human.rs
@@ -22,6 +22,13 @@ pub fn display(pattern: &Pattern, package: &Pkg) -> Result<String, Error> {
                                 pkg.yellow(),
                                 deb.version.red()
                             )?;
+                        } else if deb.newer {
+                            write!(
+                                fmt,
+                                "{} (newer, {} in debian)",
+                                pkg.yellow(),
+                                deb.version.magenta()
+                            )?;
                         } else {
                             write!(fmt, "{} (in debian)", pkg.green())?;
                         }

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -19,6 +19,7 @@ pub struct DebianJson {
     in_new: bool,
     in_unstable: bool,
     outdated: bool,
+    newer: bool,
 }
 
 impl Json {
@@ -30,6 +31,7 @@ impl Json {
             in_new: deb.in_new,
             in_unstable: deb.in_unstable,
             outdated: deb.outdated,
+            newer: deb.newer,
         });
 
         Json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use crate::args::Opts;
+use crate::db::Connection;
 use crate::errors::*;
 use clap::Parser;
 use std::io;
@@ -21,7 +22,7 @@ fn main() -> Result<(), Error> {
     info!("Building graph");
     let mut graph = graph::build(&args, metadata)?;
     info!("Populating with debian data");
-    debian::populate(&mut graph, &args)?;
+    debian::populate(&mut graph, &args, &Connection::new)?;
     info!("Printing graph");
     tree::print(&args, &graph, &mut io::stdout())?;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -514,7 +514,7 @@ mod tests {
         let expected = " \
 🔴 cargo-test v1.0.0 (/private/tmp/cargo-test)
     ├── a v1.0.0 (in debian) (/private/tmp/cargo-test/a)
- ⌛ ├── b v1.0.0 (outdated, 2.1.0 in debian) (/private/tmp/cargo-test/b)
+ 🔽 ├── b v1.0.0 (newer, 2.1.0 in debian) (/private/tmp/cargo-test/b)
  ⌛ ├── c v1.0.0 (outdated, 0.4.5 in debian) (/private/tmp/cargo-test/c)
  🔴 └── d v1.0.0 (/private/tmp/cargo-test/d)\n";
         assert_eq!(output, expected);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -351,9 +351,17 @@ mod tests {
     use anyhow::Error;
     use cargo_metadata::Metadata;
     use clap::Parser;
+    use strip_ansi_escapes::strip;
 
     use super::print;
-    use crate::{args::Args, graph};
+    use crate::{
+        args::Args,
+        db::{
+            tests::{mock_connection, MockClient},
+            Connection,
+        },
+        debian, graph,
+    };
 
     #[test]
     fn print_tree_without_dependency_loop() -> Result<(), Error> {
@@ -413,6 +421,103 @@ mod tests {
  🔴         └── c v0.1.0 (/private/tmp/cargo-test/c)
 "#;
         assert_eq!(String::from_utf8(buffer)?, expected);
+        Ok(())
+    }
+
+    fn new_mock_connection() -> Result<Connection<MockClient<'static>>, Error> {
+        // TODO: the tmp dir created by this test isn't deleted.
+        // Change ownership so that it is.
+        let tmpdir = Box::leak(Box::new(
+            tempfile::tempdir()
+                .expect("could not create a temporary directory for the cache")
+                .keep(),
+        ));
+        let mocked_responses = Box::leak(Box::new(vec![
+            (
+                "SELECT version::text FROM sources WHERE source in ($1, $2) AND release='sid';",
+                vec!["rust-a", "rust-a-1"],
+                vec![vec!["1.0.0-2"]],
+            ),
+            (
+                "SELECT version::text FROM packages WHERE package in ($1, $2) AND release='sid';",
+                vec!["librust-a-dev", "librust-a-1-dev"],
+                vec![vec!["1.0.0-2"]],
+            ),
+            (
+                "SELECT version::text FROM sources WHERE source in ($1, $2) AND release='sid';",
+                vec!["rust-b", "rust-b-1"],
+                vec![vec!["2.1.0-1"]],
+            ),
+            (
+                "SELECT version::text FROM packages WHERE package in ($1, $2) AND release='sid';",
+                vec!["librust-b-dev", "librust-b-1-dev"],
+                vec![vec!["2.1.0-1"]],
+            ),
+            (
+                "SELECT version::text FROM sources WHERE source in ($1, $2) AND release='sid';",
+                vec!["rust-c", "rust-c-1"],
+                vec![vec!["0.4.5-1"]],
+            ),
+            (
+                "SELECT version::text FROM packages WHERE package in ($1, $2) AND release='sid';",
+                vec!["librust-c-dev", "librust-c-1-dev"],
+                vec![vec!["0.4.5-1"]],
+            ),
+            (
+                "SELECT version::text FROM sources WHERE source in ($1, $2) AND release='sid';",
+                vec!["rust-d", "rust-d-1"],
+                vec![],
+            ),
+            (
+                "SELECT version::text FROM new_sources WHERE source in ($1, $2);",
+                vec!["rust-d", "rust-d-1"],
+                vec![],
+            ),
+            (
+                "SELECT version::text FROM packages WHERE package in ($1, $2) AND release='sid';",
+                vec!["librust-d-dev", "librust-d-1-dev"],
+                vec![],
+            ),
+            (
+                "SELECT version::text FROM sources WHERE source in ($1, $2) AND release='sid';",
+                vec!["rust-cargo-test", "rust-cargo-test-1"],
+                vec![],
+            ),
+            (
+                "SELECT version::text FROM new_sources WHERE source in ($1, $2);",
+                vec!["rust-cargo-test", "rust-cargo-test-1"],
+                vec![],
+            ),
+            (
+                "SELECT version::text FROM packages WHERE package in ($1, $2) AND release='sid';",
+                vec!["librust-cargo-test-dev", "librust-cargo-test-1-dev"],
+                vec![],
+            ),
+        ]));
+        Ok(mock_connection(tmpdir, mocked_responses))
+    }
+
+    #[test]
+    fn print_dependency_status_in_debian() -> Result<(), Error> {
+        let args = Args::parse_from(["debstatus"]);
+        let metadata: Metadata = serde_json::from_str(include_str!(
+            "../tests/data/cargo_metadata_with_flat_dependencies.json"
+        ))?;
+        let mut graph = graph::build(&args, metadata)?;
+        debian::populate(&mut graph, &args, &new_mock_connection)?;
+        let mut buffer = Vec::new();
+
+        print(&args, &graph, &mut buffer)?;
+
+        let output = String::from_utf8(strip(buffer)).unwrap();
+
+        let expected = " \
+🔴 cargo-test v1.0.0 (/private/tmp/cargo-test)
+    ├── a v1.0.0 (in debian) (/private/tmp/cargo-test/a)
+ ⌛ ├── b v1.0.0 (outdated, 2.1.0 in debian) (/private/tmp/cargo-test/b)
+ ⌛ ├── c v1.0.0 (outdated, 0.4.5 in debian) (/private/tmp/cargo-test/c)
+ 🔴 └── d v1.0.0 (/private/tmp/cargo-test/d)\n";
+        assert_eq!(output, expected);
         Ok(())
     }
 }

--- a/tests/data/cargo_metadata_with_flat_dependencies.json
+++ b/tests/data/cargo_metadata_with_flat_dependencies.json
@@ -1,0 +1,371 @@
+{
+  "packages": [
+    {
+      "name": "a",
+      "version": "1.0.0",
+      "id": "path+file:///private/tmp/cargo-test/a#1.0.0",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [],
+      "targets": [
+        {
+          "kind": [
+            "lib"
+          ],
+          "crate_types": [
+            "lib"
+          ],
+          "name": "a",
+          "src_path": "/private/tmp/cargo-test/a/src/lib.rs",
+          "edition": "2024",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "/private/tmp/cargo-test/a/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2024",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    },
+    {
+      "name": "b",
+      "version": "1.0.0",
+      "id": "path+file:///private/tmp/cargo-test/b#1.0.0",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [],
+      "targets": [
+        {
+          "kind": [
+            "lib"
+          ],
+          "crate_types": [
+            "lib"
+          ],
+          "name": "b",
+          "src_path": "/private/tmp/cargo-test/b/src/lib.rs",
+          "edition": "2024",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "/private/tmp/cargo-test/b/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2024",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    },
+    {
+      "name": "c",
+      "version": "1.0.0",
+      "id": "path+file:///private/tmp/cargo-test/c#1.0.0",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [],
+      "targets": [
+        {
+          "kind": [
+            "lib"
+          ],
+          "crate_types": [
+            "lib"
+          ],
+          "name": "c",
+          "src_path": "/private/tmp/cargo-test/c/src/lib.rs",
+          "edition": "2024",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "/private/tmp/cargo-test/c/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2024",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    },
+    {
+      "name": "cargo-test",
+      "version": "1.0.0",
+      "id": "path+file:///private/tmp/cargo-test#1.0.0",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [
+        {
+          "name": "a",
+          "source": null,
+          "req": "*",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null,
+          "path": "/private/tmp/cargo-test/a"
+        },
+        {
+          "name": "b",
+          "source": null,
+          "req": "*",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null,
+          "path": "/private/tmp/cargo-test/b"
+        },
+        {
+          "name": "c",
+          "source": null,
+          "req": "*",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null,
+          "path": "/private/tmp/cargo-test/c"
+        },
+        {
+          "name": "d",
+          "source": null,
+          "req": "*",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null,
+          "path": "/private/tmp/cargo-test/d"
+        }
+      ],
+      "targets": [
+        {
+          "kind": [
+            "bin"
+          ],
+          "crate_types": [
+            "bin"
+          ],
+          "name": "cargo-test",
+          "src_path": "/private/tmp/cargo-test/src/main.rs",
+          "edition": "2024",
+          "doc": true,
+          "doctest": false,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "/private/tmp/cargo-test/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2024",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    },
+    {
+      "name": "d",
+      "version": "1.0.0",
+      "id": "path+file:///private/tmp/cargo-test/d#1.0.0",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [
+        {
+          "name": "b",
+          "source": null,
+          "req": "*",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null,
+          "path": "/private/tmp/cargo-test/b"
+        }
+      ],
+      "targets": [
+        {
+          "kind": [
+            "lib"
+          ],
+          "crate_types": [
+            "lib"
+          ],
+          "name": "d",
+          "src_path": "/private/tmp/cargo-test/d/src/lib.rs",
+          "edition": "2024",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "/private/tmp/cargo-test/d/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2024",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    }
+  ],
+  "workspace_members": [
+    "path+file:///private/tmp/cargo-test#1.0.0",
+    "path+file:///private/tmp/cargo-test/a#1.0.0",
+    "path+file:///private/tmp/cargo-test/b#1.0.0",
+    "path+file:///private/tmp/cargo-test/c#1.0.0",
+    "path+file:///private/tmp/cargo-test/d#1.0.0"
+  ],
+  "workspace_default_members": [
+    "path+file:///private/tmp/cargo-test#1.0.0"
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "id": "path+file:///private/tmp/cargo-test/a#1.0.0",
+        "dependencies": [],
+        "deps": [],
+        "features": []
+      },
+      {
+        "id": "path+file:///private/tmp/cargo-test/b#1.0.0",
+        "dependencies": [],
+        "deps": [],
+        "features": []
+      },
+      {
+        "id": "path+file:///private/tmp/cargo-test/c#1.0.0",
+        "dependencies": [],
+        "deps": [],
+        "features": []
+      },
+      {
+        "id": "path+file:///private/tmp/cargo-test#1.0.0",
+        "dependencies": [
+          "path+file:///private/tmp/cargo-test/a#1.0.0",
+          "path+file:///private/tmp/cargo-test/b#1.0.0",
+          "path+file:///private/tmp/cargo-test/c#1.0.0",
+          "path+file:///private/tmp/cargo-test/d#1.0.0"
+        ],
+        "deps": [
+          {
+            "name": "a",
+            "pkg": "path+file:///private/tmp/cargo-test/a#1.0.0",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
+          },
+          {
+            "name": "b",
+            "pkg": "path+file:///private/tmp/cargo-test/b#1.0.0",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
+          },
+          {
+            "name": "c",
+            "pkg": "path+file:///private/tmp/cargo-test/c#1.0.0",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
+          },
+          {
+            "name": "d",
+            "pkg": "path+file:///private/tmp/cargo-test/d#1.0.0",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
+          }
+        ],
+        "features": []
+      },
+      {
+        "id": "path+file:///private/tmp/cargo-test/d#1.0.0",
+        "dependencies": [],
+        "deps": [],
+        "features": []
+      }
+    ],
+    "root": "path+file:///private/tmp/cargo-test#1.0.0"
+  },
+  "target_directory": "/private/tmp/cargo-test/target",
+  "version": 1,
+  "workspace_root": "/private/tmp/cargo-test",
+  "metadata": null
+}


### PR DESCRIPTION
As suggested by @werdahias and @alexanderkjall in https://github.com/kpcyrd/cargo-debstatus/pull/16#discussion_r1097900833, this introduces a distinction between two states:
* when the crate is outdated in debian
* when the crate is newer in debian

Currently, those two states are both rendered as "outdated", which can be a bit confusing.