### PR TITLE
First implementation of `--filter missing`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -69,9 +69,9 @@ pub struct Args {
     #[clap(long = "no-dev-dependencies")]
     /// Skip dev dependencies.
     pub no_dev_dependencies: bool,
-    #[clap(long = "filter", default_value_t=DependencyFilter::All)]
+    #[clap(long = "filter", value_delimiter = ',')]
     /// Filter dependencies based on their debian availability
-    pub filter: DependencyFilter,
+    pub filter: Vec<DependencyFilter>,
     #[clap(long = "manifest-path", value_name = "PATH")]
     /// Path to Cargo.toml
     pub manifest_path: Option<PathBuf>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,6 +3,8 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::filter::DependencyFilter;
+
 #[derive(Parser)]
 #[clap(bin_name = "cargo")]
 pub enum Opts {
@@ -67,6 +69,9 @@ pub struct Args {
     #[clap(long = "no-dev-dependencies")]
     /// Skip dev dependencies.
     pub no_dev_dependencies: bool,
+    #[clap(long = "filter", default_value_t=DependencyFilter::All)]
+    /// Filter dependencies based on their debian availability
+    pub filter: DependencyFilter,
     #[clap(long = "manifest-path", value_name = "PATH")]
     /// Path to Cargo.toml
     pub manifest_path: Option<PathBuf>,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,102 @@
+use crate::debian::PackagingProgress;
+use cargo_metadata::DependencyKind;
+use clap::ValueEnum;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::EdgeRef;
+use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
+
+use crate::debian::Pkg;
+use crate::graph::Graph;
+
+#[derive(ValueEnum, Clone, Default, Debug, PartialEq, Eq)]
+pub enum DependencyFilter {
+    /// Show all dependencies (default)
+    #[default]
+    All,
+    /// Only show missing dependencies, which require going through the NEW queue.
+    /// Missing dependencies of crates that are newer in Debian are ignored.
+    Missing,
+}
+
+impl Display for DependencyFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            DependencyFilter::All => "all",
+            DependencyFilter::Missing => "missing",
+        })
+    }
+}
+
+impl DependencyFilter {
+    /// Run the filter on a graph, mutating it.
+    pub fn run(&self, graph: &mut Graph) {
+        match self {
+            DependencyFilter::All => (),
+            DependencyFilter::Missing => {
+                let mut visited = HashSet::new();
+                let mut cache = HashMap::new();
+                for node_index in graph.graph.node_indices() {
+                    has_missing_dependency(graph, node_index, &mut visited, &mut cache);
+                }
+
+                graph.graph.retain_edges(|graph, edge| {
+                    (*graph)
+                        .edge_endpoints(edge)
+                        .is_some_and(|(source, target)| {
+                            if let (Some(&a), Some(&b)) = (cache.get(&source), cache.get(&target)) {
+                                a && b
+                            } else {
+                                false
+                            }
+                        })
+                });
+            }
+        }
+    }
+}
+
+fn has_missing_dependency(
+    graph: &Graph,
+    node_index: NodeIndex<u32>,
+    visited: &mut HashSet<NodeIndex<u32>>,
+    cache: &mut HashMap<NodeIndex<u32>, bool>,
+) -> bool {
+    if let Some(result) = cache.get(&node_index) {
+        *result
+    } else if visited.contains(&node_index) {
+        // dependency loop: we don't recurse, to avoid a stack overflow.
+        false
+    } else {
+        visited.insert(node_index);
+        let edges = graph
+            .graph
+            .edges_directed(node_index, petgraph::Direction::Outgoing);
+        let package: &Pkg = &graph.graph[node_index];
+        let mut missing_dep_found = !package.in_debian();
+        for edge in edges {
+            let edge_kind = graph
+                .graph
+                .edge_weight(edge.id())
+                .unwrap_or(&DependencyKind::Unknown);
+            if ![
+                DependencyKind::Build,
+                DependencyKind::Development,
+                DependencyKind::Build,
+            ]
+            .contains(edge_kind)
+            {
+                continue;
+            }
+            let dep_has_missing_dep = has_missing_dependency(graph, edge.target(), visited, cache);
+            missing_dep_found = missing_dep_found || dep_has_missing_dep;
+        }
+        // If the package is newer in debian, ignore any missing dependencies of it,
+        // because there is no point packaging the dependencies of an older version of it.
+        if matches!(package.packaging_status(), PackagingProgress::NeedsPatching) {
+            missing_dep_found = false;
+        }
+        cache.insert(node_index, missing_dep_found);
+        missing_dep_found
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -17,6 +17,8 @@ pub enum DependencyFilter {
     /// Only show missing dependencies, which require going through the NEW queue.
     /// Missing dependencies of crates that are newer in Debian are ignored.
     Missing,
+    /// Remove all the workspace dependencies to keep only third-party ones
+    ThirdParty,
 }
 
 impl Display for DependencyFilter {
@@ -24,6 +26,7 @@ impl Display for DependencyFilter {
         f.write_str(match self {
             DependencyFilter::All => "all",
             DependencyFilter::Missing => "missing",
+            DependencyFilter::ThirdParty => "third-party",
         })
     }
 }
@@ -50,6 +53,14 @@ impl DependencyFilter {
                                 false
                             }
                         })
+                });
+            }
+            DependencyFilter::ThirdParty => {
+                graph.graph.retain_edges(|graph, edge| {
+                    (*graph).edge_endpoints(edge).is_some_and(|(_, target)| {
+                        let target_pkg: &Pkg = &graph[target];
+                        !target_pkg.workspace_member
+                    })
                 });
             }
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,6 +7,7 @@ use petgraph::stable_graph::StableGraph;
 use petgraph::visit::Dfs;
 use std::collections::{HashMap, HashSet};
 
+#[derive(Clone)]
 pub struct Graph {
     pub graph: StableGraph<Pkg, DependencyKind>,
     pub nodes: HashMap<PackageId, NodeIndex>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,9 @@ fn main() -> Result<(), Error> {
     let mut graph = graph::build(&args, metadata)?;
     info!("Populating with debian data");
     debian::populate(&mut graph, &args, &Connection::new)?;
-    args.filter.run(&mut graph);
+    for filter in &args.filter {
+        filter.run(&mut graph);
+    }
     info!("Printing graph");
     tree::print(&args, &graph, &mut io::stdout())?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod args;
 mod db;
 mod debian;
 mod errors;
+mod filter;
 mod format;
 mod graph;
 mod metadata;
@@ -29,6 +30,7 @@ fn main() -> Result<(), Error> {
     let mut graph = graph::build(&args, metadata)?;
     info!("Populating with debian data");
     debian::populate(&mut graph, &args, &Connection::new)?;
+    args.filter.run(&mut graph);
     info!("Printing graph");
     tree::print(&args, &graph, &mut io::stdout())?;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -523,4 +523,27 @@ mod tests {
         assert_eq!(output, expected);
         Ok(())
     }
+
+    #[test]
+    fn print_only_missing() -> Result<(), Error> {
+        let args = Args::parse_from(["debstatus", "--filter", "missing", "-p", "cargo-test"]);
+        let metadata: Metadata = serde_json::from_str(include_str!(
+            "../tests/data/cargo_metadata_with_flat_dependencies.json"
+        ))?;
+        let mut graph = graph::build(&args, metadata)?;
+        debian::populate(&mut graph, &args, &new_mock_connection)?;
+        args.filter.run(&mut graph);
+        let mut buffer = Vec::new();
+
+        print(&args, &graph, &mut buffer)?;
+
+        let output = String::from_utf8(buffer).unwrap();
+        println!("{output}");
+
+        let expected = " \
+🪏  cargo-test v1.0.0 (in workspace, /private/tmp/cargo-test)
+ 🪏  └── d v1.0.0 (in workspace, /private/tmp/cargo-test/d)\n";
+        assert_eq!(output, expected);
+        Ok(())
+    }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -532,7 +532,9 @@ mod tests {
         ))?;
         let mut graph = graph::build(&args, metadata)?;
         debian::populate(&mut graph, &args, &new_mock_connection)?;
-        args.filter.run(&mut graph);
+        for filter in &args.filter {
+            filter.run(&mut graph);
+        }
         let mut buffer = Vec::new();
 
         print(&args, &graph, &mut buffer)?;
@@ -543,6 +545,30 @@ mod tests {
         let expected = " \
 🪏  cargo-test v1.0.0 (in workspace, /private/tmp/cargo-test)
  🪏  └── d v1.0.0 (in workspace, /private/tmp/cargo-test/d)\n";
+        assert_eq!(output, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn print_third_party() -> Result<(), Error> {
+        let args = Args::parse_from(["debstatus", "--filter", "third-party", "-p", "cargo-test"]);
+        let metadata: Metadata = serde_json::from_str(include_str!(
+            "../tests/data/cargo_metadata_with_flat_dependencies.json"
+        ))?;
+        let mut graph = graph::build(&args, metadata)?;
+        debian::populate(&mut graph, &args, &new_mock_connection)?;
+        for filter in &args.filter {
+            filter.run(&mut graph);
+        }
+        let mut buffer = Vec::new();
+
+        print(&args, &graph, &mut buffer)?;
+
+        let output = String::from_utf8(buffer).unwrap();
+        println!("{output}");
+
+        let expected = " \
+🪏  cargo-test v1.0.0 (in workspace, /private/tmp/cargo-test)\n";
         assert_eq!(output, expected);
         Ok(())
     }


### PR DESCRIPTION
Adds support for showing only missing dependencies.
Missing dependencies of crates which are newer in Debian are ignored (because they don't need packaging).

Closes #10.

Draft because better tests would be nice.